### PR TITLE
Typo with Power wish granting Dictatorship government

### DIFF
--- a/strings/strings.json
+++ b/strings/strings.json
@@ -5635,7 +5635,7 @@
   "wish_potato": "Potato Battery",
   "wish_energized": "You feel energized.",
   "wish_ship": "New reports indicate that your warships are more effective then previously thought.",
-  "wish_gov": "In a suprise turn of events, your government has desolved itself and declared you to be the supreme ruler with total authority.",
+  "wish_gov": "In a suprise turn of events, your government has dissolved itself and declared you to be the supreme ruler with total authority.",
   "wish_dictator": "Dictator",
   "wish_priest": "You have gained a devout follower.",
   "wish_priest_fail": "The cosmos have decree that you have enough fanatical followers.",


### PR DESCRIPTION
"In a surprise turn of events, your government has desolved itself and declared you to be the supreme ruler with total authority." "desolved" is a typo of "dissolved"!